### PR TITLE
Ensure reference values fall back to local catalog data

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -61,6 +61,38 @@ def replace_nan_with_none(obj):
     return obj
 
 
+def prepare_planet_dataset(planet_name, api_data, hwc_df, hz_gallery_df, logger):
+    """Prepare combined planet data even when the external API is unavailable."""
+
+    normalized_planet_name = None
+
+    if api_data is not None:
+        if "pl_name" not in api_data or pd.isna(api_data.get("pl_name")):
+            api_data["pl_name"] = planet_name
+        normalized_planet_name = normalize_name(api_data.get("pl_name", planet_name))
+    else:
+        logger.warning(
+            "Could not fetch API data for %s. Falling back to local catalogues for reference values.",
+            planet_name,
+        )
+        normalized_planet_name = normalize_name(planet_name)
+
+    combined_data = merge_data_sources(
+        api_data,
+        hwc_df,
+        hz_gallery_df,
+        normalized_planet_name,
+    )
+
+    if not combined_data:
+        logger.warning("No combined data available for %s after attempting fallbacks.", planet_name)
+        return None, None
+
+    combined_data.setdefault("pl_name", planet_name)
+
+    return normalized_planet_name, combined_data
+
+
 def get_template_env():
     """Initializes and returns a Jinja2 template environment.
 
@@ -366,15 +398,20 @@ def configure():
             logger.info(f"Processing reference values for planet: {planet_name}")
             api_data = fetch_exoplanet_data_api(planet_name)
 
-            if api_data is None:
-                logger.warning(f"Could not fetch API data for reference values of {planet_name}.")
+            normalized_planet_name, combined_data = prepare_planet_dataset(
+                planet_name,
+                api_data,
+                hwc_df,
+                hz_gallery_df,
+                logger,
+            )
+
+            if not normalized_planet_name or not combined_data:
+                logger.warning(
+                    "Skipping %s because no combined data could be prepared for reference values.",
+                    planet_name,
+                )
                 continue
-
-            if "pl_name" not in api_data or pd.isna(api_data.get("pl_name")):
-                api_data["pl_name"] = planet_name
-
-            normalized_planet_name = normalize_name(api_data.get("pl_name", planet_name))
-            combined_data = merge_data_sources(api_data, hwc_df, hz_gallery_df, normalized_planet_name)
 
             logger.debug(f"Combined data for {normalized_planet_name}: {combined_data}")
 
@@ -538,15 +575,20 @@ def get_planet_reference_values():
         logger.info(f"Processing reference values for planet: {planet_name}")
         api_data = fetch_exoplanet_data_api(planet_name)
 
-        if api_data is None:
-            logger.warning(f"Could not fetch API data for reference values of {planet_name}.")
+        normalized_planet_name, combined_data = prepare_planet_dataset(
+            planet_name,
+            api_data,
+            hwc_df,
+            hz_gallery_df,
+            logger,
+        )
+
+        if not normalized_planet_name or not combined_data:
+            logger.warning(
+                "Skipping %s because no combined data could be prepared for reference values.",
+                planet_name,
+            )
             continue
-
-        if "pl_name" not in api_data or pd.isna(api_data.get("pl_name")):
-            api_data["pl_name"] = planet_name
-
-        normalized_planet_name = normalize_name(api_data.get("pl_name", planet_name))
-        combined_data = merge_data_sources(api_data, hwc_df, hz_gallery_df, normalized_planet_name)
 
         weights = {
             "habitability": dict(global_habitability_weights),


### PR DESCRIPTION
## Summary
- add a helper that prepares planet datasets using cached catalogues when the NASA API is unavailable
- update the configure page and reference values API to use the fallback helper so the table is populated even without API access

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1ab1ef7848329a528448e8acac7de